### PR TITLE
Feature persistent console

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      # - name: Docker Layer Caching
-      #   uses: satackey/action-docker-layer-caching@v0.0.8
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.8
 
       - name: build image
         run: docker build -t ${{ secrets.REGISTRY_USERNAME }}/minetest:${GITHUB_REF##*/} .

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Start youtube2text
+# Start 9mine
 This repository provides minetest mod for converting youtube video to text
 
 To start:
 
 1. Clone this branch and cd into directory
 
-        git clone --depth=1 https://github.com/9mine/9mine.git && cd 9mine
+        git clone --depth=1 https://github.com/9mine/9mine.git
 
 2. Update Docker Images
 

--- a/mods/core/9p/file_read.lua
+++ b/mods/core/9p/file_read.lua
@@ -1,7 +1,7 @@
 file_read = function(addr, path, player_name)
     local conn = connections[player_name][addr]
     local f = conn:newfid()
-    np:walk(conn.rootfid, f, path)
+    conn:walk(conn.rootfid, f, path)
     conn:open(f, 0)
     local buf_size = 4096
     local offset = 0

--- a/mods/core/9p/stat_read.lua
+++ b/mods/core/9p/stat_read.lua
@@ -1,7 +1,7 @@
 stat_read = function(addr, path, player_name)
     local conn = connections[player_name][addr]
     local f = conn:newfid()
-    np:walk(conn.rootfid, f, path)
+    conn:walk(conn.rootfid, f, path)
     conn:open(f, 0)
     local st = conn:stat(f)
     conn:clunk(f)

--- a/mods/core/entities/console.lua
+++ b/mods/core/entities/console.lua
@@ -41,7 +41,13 @@ minetest.register_entity("core:console", {
 
     get_staticdata = function(self)
         local attributes = self.object:get_nametag_attributes()
-        local data = {attr = attributes, path = self.path, addr = self.addr}
+        local data = {
+            attr = attributes,
+            path = self.path,
+            addr = self.addr,
+            input = self.input,
+            output = self.output
+        }
         return minetest.serialize(data)
     end,
 
@@ -51,6 +57,9 @@ minetest.register_entity("core:console", {
             self.object:set_nametag_attributes(data.attr)
             self.path = data.path
             self.addr = data.addr
+            self.input = data.input
+            self.output = data.output
+
         end
     end
 })

--- a/mods/core/entities/console.lua
+++ b/mods/core/entities/console.lua
@@ -25,7 +25,8 @@ minetest.register_entity("core:console", {
 
         local formspec = {
             "formspec_version[3]", "size[13,13,false]",
-            "textarea[0.5,0.5;12.0,10;;;" .. self.output .. "]",
+            "textarea[0.5,0.5;12.0,10;;;" ..
+                minetest.formspec_escape(self.output) .. "]",
             "field[0.5,10.5;12,1;input;;\\; ]",
             "field_close_on_enter[input;false]",
             "button[10,11.6;2.5,0.9;send;send]",
@@ -34,8 +35,7 @@ minetest.register_entity("core:console", {
         }
         local form = table.concat(formspec, "")
 
-        minetest.show_formspec(player:get_player_name(), "control9p:console",
-                               form)
+        minetest.show_formspec(player:get_player_name(), "core:console", form)
 
     end,
 

--- a/mods/core/entities/console.lua
+++ b/mods/core/entities/console.lua
@@ -1,0 +1,56 @@
+minetest.register_entity("core:console", {
+    initial_properties = {
+        physical = true,
+        pointable = true,
+        visual = "cube",
+        collide_with_objects = true,
+        textures = {
+            "core_console.png", "core_console.png", "core_console.png",
+            "core_console.png", "core_console.png", "core_console.png"
+        },
+        is_visible = true,
+        nametag_color = "black",
+        static_save = true,
+        shaded = true
+    },
+    path = "",
+    addr = "",
+    output = "",
+    input = "",
+    on_punch = function(self, player, dtime, tool, dir)
+        local p = self.object:get_pos()
+        print(dump(p))
+        local pos = minetest.serialize(p)
+        print(pos)
+
+        local formspec = {
+            "formspec_version[3]", "size[13,13,false]",
+            "textarea[0.5,0.5;12.0,10;;;" .. self.output .. "]",
+            "field[0.5,10.5;12,1;input;;\\; ]",
+            "field_close_on_enter[input;false]",
+            "button[10,11.6;2.5,0.9;send;send]",
+            "field[13,13;0,0;entity_pos;;" .. minetest.formspec_escape(pos) ..
+                "]"
+        }
+        local form = table.concat(formspec, "")
+
+        minetest.show_formspec(player:get_player_name(), "control9p:console",
+                               form)
+
+    end,
+
+    get_staticdata = function(self)
+        local attributes = self.object:get_nametag_attributes()
+        local data = {attr = attributes, path = self.path, addr = self.addr}
+        return minetest.serialize(data)
+    end,
+
+    on_activate = function(self, staticdata, dtime_s)
+        if staticdata ~= "" and staticdata ~= nil then
+            local data = minetest.deserialize(staticdata) or {}
+            self.object:set_nametag_attributes(data.attr)
+            self.path = data.path
+            self.addr = data.addr
+        end
+    end
+})

--- a/mods/core/entities/console.lua
+++ b/mods/core/entities/console.lua
@@ -19,10 +19,7 @@ minetest.register_entity("core:console", {
     input = "",
     on_punch = function(self, player, dtime, tool, dir)
         local p = self.object:get_pos()
-        print(dump(p))
         local pos = minetest.serialize(p)
-        print(pos)
-
         local formspec = {
             "formspec_version[3]", "size[13,13,false]",
             "textarea[0.5,0.5;12.0,10;;;" ..

--- a/mods/core/events/console.lua
+++ b/mods/core/events/console.lua
@@ -1,7 +1,6 @@
 console = function(player, formname, fields)
-    print("You zzzz here")
     if fields["quit"] then return end
-    player_name = player:get_player_name()
+    local player_name = player:get_player_name()
     local p = fields["entity_pos"]
     local pos = minetest.deserialize(p)
     local entity = get_entity(pos)
@@ -9,10 +8,8 @@ console = function(player, formname, fields)
     local path = entity:get_luaentity().path
     local lcmd = tostring(core_conf:get("lcmd"))
     local inpt = fields["input"]:gsub("; ", "")
-    print("You were here")
     cmd_write(addr, path, player_name, fields["input"], lcmd)
     local response = cmd_read(addr, player_name, lcmd)
-    print("You rocks here")
     entity:get_luaentity().output =
         fields["input"] .. ": " .. response .. "\n" ..
             entity:get_luaentity().output

--- a/mods/core/events/console.lua
+++ b/mods/core/events/console.lua
@@ -1,0 +1,30 @@
+console = function(player, formname, fields)
+    print("You zzzz here")
+    if fields["quit"] then return end
+    player_name = player:get_player_name()
+    local p = fields["entity_pos"]
+    local pos = minetest.deserialize(p)
+    local entity = get_entity(pos)
+    local addr = entity:get_luaentity().addr
+    local path = entity:get_luaentity().path
+    local lcmd = tostring(core_conf:get("lcmd"))
+    local inpt = fields["input"]:gsub("; ", "")
+    print("You were here")
+    cmd_write(addr, path, player_name, fields["input"], lcmd)
+    local response = cmd_read(addr, player_name, lcmd)
+    print("You rocks here")
+    entity:get_luaentity().output =
+        fields["input"] .. ": " .. response .. "\n" ..
+            entity:get_luaentity().output
+    local formspec = {
+        "formspec_version[3]", "size[13,13,false]",
+        "textarea[0.5,0.5;12.0,10;;;" ..
+            minetest.formspec_escape(entity:get_luaentity().output) .. "]",
+        "field[0.5,10.5;12,1;input;;\\; ]", "field_close_on_enter[input;false]",
+        "button[10,11.6;2.5,0.9;send;send]",
+        "field[13,13;0,0;entity_pos;;" .. minetest.formspec_escape(p) .. "]"
+    }
+    local form = table.concat(formspec, "")
+
+    minetest.show_formspec(player_name, "core:console", form)
+end

--- a/mods/core/events/events.lua
+++ b/mods/core/events/events.lua
@@ -3,7 +3,10 @@ minetest.register_on_player_receive_fields(
         if formname == "core:spawn_attach" then
             spawn_attach(player, formname, fields)
         end
+        if formname == "core:spawn_console" then
+            spawn_console(player, formname, fields)
+        end
         if formname == "core:console" then
-            spawn_attach(player, formname, fields)
+            console(player, formname, fields)
         end
     end)

--- a/mods/core/events/events.lua
+++ b/mods/core/events/events.lua
@@ -4,6 +4,6 @@ minetest.register_on_player_receive_fields(
             spawn_attach(player, formname, fields)
         end
         if formname == "core:console" then
-            console(player, formname, fields)
+            spawn_attach(player, formname, fields)
         end
     end)

--- a/mods/core/events/spawn_console.lua
+++ b/mods/core/events/spawn_console.lua
@@ -1,0 +1,14 @@
+spawn_console = function(player, formname, fields)
+    local addr, path, player = connect(player, formname, fields)
+    print("You are here")
+    if addr and path and player then
+        local dir = player:get_look_dir()
+        local dis = vector.multiply(dir, 5)
+        local pp = player:get_pos()
+        local fp = vector.add(pp, dis)
+        fp.y = fp.y + 2
+        local entity = minetest.add_entity(fp, "core:console")
+        entity:set_properties({nametag = addr})
+    end
+end
+

--- a/mods/core/events/spawn_console.lua
+++ b/mods/core/events/spawn_console.lua
@@ -8,7 +8,7 @@ spawn_console = function(player, formname, fields)
         fp.y = fp.y + 2
         local entity = minetest.add_entity(fp, "core:console")
         entity:set_properties({nametag = addr})
-        entity:get_luaentity().addr = addr 
+        entity:get_luaentity().addr = addr
         entity:get_luaentity().path = path
     end
 end

--- a/mods/core/events/spawn_console.lua
+++ b/mods/core/events/spawn_console.lua
@@ -1,6 +1,5 @@
 spawn_console = function(player, formname, fields)
     local addr, path, player = connect(player, formname, fields)
-    print("You are here")
     if addr and path and player then
         local dir = player:get_look_dir()
         local dis = vector.multiply(dir, 5)
@@ -9,6 +8,8 @@ spawn_console = function(player, formname, fields)
         fp.y = fp.y + 2
         local entity = minetest.add_entity(fp, "core:console")
         entity:set_properties({nametag = addr})
+        entity:get_luaentity().addr = addr 
+        entity:get_luaentity().path = path
     end
 end
 

--- a/mods/core/funcs/cmd/cmd_read.lua
+++ b/mods/core/funcs/cmd/cmd_read.lua
@@ -3,7 +3,7 @@
 cmd_read = function(addr, player_name, lcmd)
     local conn = connections[player_name][addr]
     local f = conn:newfid()
-    np.walk(conn, conn.rootfid, f, lcmd)
+    conn:walk(conn.rootfid, f, lcmd)
     conn:open(f, 0)
     local buf_size = 4096
     local offset = 0

--- a/mods/core/funcs/cmd/cmd_read.lua
+++ b/mods/core/funcs/cmd/cmd_read.lua
@@ -3,7 +3,7 @@
 cmd_read = function(addr, player_name, lcmd)
     local conn = connections[player_name][addr]
     local f = conn:newfid()
-    np:walk(conn.rootfid, f, lcmd)
+    np.walk(conn, conn.rootfid, f, lcmd)
     conn:open(f, 0)
     local buf_size = 4096
     local offset = 0

--- a/mods/core/funcs/connect.lua
+++ b/mods/core/funcs/connect.lua
@@ -30,7 +30,7 @@ connect = function(player, formname, fields)
     if not addr_node then
         addr_node = g:node(addr, {host_info = host_info, addr = addr})
         local player_node = g:findnode(player_name)
-        -- g:edge(player_node, addr_node, player_name .. "->" .. addr)
+        g:edge(player_node, addr_node, player_name .. "->" .. addr)
     else
     end
 

--- a/mods/core/funcs/connect.lua
+++ b/mods/core/funcs/connect.lua
@@ -3,14 +3,15 @@ connect = function(player, formname, fields)
     if not (fields.spawn_attach or fields.key_enter) then return end
 
     local player_name = player:get_player_name()
-    local addr = fields.remote_address
-    if not addr or (addr == "") then
+    local remote_address = fields.remote_address
+    if not remote_address or (remote_address == "") then
         send_warning(player_name, "No connection string provided")
         return
     end
 
     -- parse provided string and handle errors
-    local host_info, addr, path = parse_remote_address(addr)
+    local host_info, addr, path = parse_remote_address(remote_address)
+
     if not host_info or not addr or not path then
         send_warning(player_name,
                      "Connection string parser returned no information")
@@ -31,15 +32,16 @@ connect = function(player, formname, fields)
         addr_node = g:node(addr, {host_info = host_info, addr = addr})
         local player_node = g:findnode(player_name)
         g:edge(player_node, addr_node, player_name .. "->" .. addr)
-    else
     end
 
     -- retrieve 9p attached connection or create new if not exists
     local conn = connections[player_name][addr]
+
     if not conn then
         print("Connecting to " .. addr .. " . . . ")
         local tcp = socket:tcp()
         local _, err = tcp:connect(host_info.host, host_info.port, "*", 0)
+
         if (err ~= nil) then
             minetest.chat_send_player(player_name, "Connection error to " ..
                                           addr .. ": " .. err)

--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -22,6 +22,7 @@ core_conf = Settings(path .. "/mod.conf")
 -- entities
 dofile(path .. "/entities/dir.lua")
 dofile(path .. "/entities/file.lua")
+dofile(path .. "/entities/console.lua")
 
 -- manage platforms
 dofile(path .. "/platforms/get_size.lua")
@@ -83,8 +84,9 @@ dofile(path .. "/on_join/init_conn.lua")
 
 -- events
 dofile(path .. "/events/events.lua")
-dofile(path .. "/events/spawn_attach.lua")
 dofile(path .. "/events/console.lua")
+dofile(path .. "/events/spawn_attach.lua")
+dofile(path .. "/events/spawn_console.lua")
 
 -- chat commands
 dofile(path .. "/chat/commands/cd.lua")

--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -33,6 +33,7 @@ dofile(path .. "/platforms/update.lua")
 dofile(path .. "/tools/attach.lua")
 dofile(path .. "/tools/enter.lua")
 dofile(path .. "/tools/write.lua")
+dofile(path .. "/tools/console.lua")
 
 -- forms
 dofile(path .. "/forms/send_warning.lua")
@@ -83,6 +84,7 @@ dofile(path .. "/on_join/init_conn.lua")
 -- events
 dofile(path .. "/events/events.lua")
 dofile(path .. "/events/spawn_attach.lua")
+dofile(path .. "/events/console.lua")
 
 -- chat commands
 dofile(path .. "/chat/commands/cd.lua")

--- a/mods/core/on_join/inventory.lua
+++ b/mods/core/on_join/inventory.lua
@@ -1,5 +1,5 @@
 minetest.register_on_joinplayer(function(player)
     local inventory = player.get_inventory(player)
     populate_inventory(inventory, "core:attach",
-                       "core:enter", "core:write")
+                       "core:enter", "core:write", "core:console")
 end)

--- a/mods/core/on_join/inventory.lua
+++ b/mods/core/on_join/inventory.lua
@@ -1,5 +1,5 @@
 minetest.register_on_joinplayer(function(player)
     local inventory = player.get_inventory(player)
     populate_inventory(inventory, "core:attach",
-                       "core:enter", "core:write", "core:console")
+                       "core:enter", "core:write", "core:spawn_console")
 end)

--- a/mods/core/tools/console.lua
+++ b/mods/core/tools/console.lua
@@ -1,0 +1,22 @@
+minetest.register_tool("core:console", {
+    desription = "Attach to Console",
+    inventory_image = "core_console.png",
+    wield_image = "core_console.png",
+    tool_capabilities = {punch_attack_uses = 0, damage_groups = {console = 1}},
+
+    -- on_use = function(itemstack, player, pointed_thing)
+    --     local dir = player:get_look_dir()
+    --     local dis = vector.multiply(dir, 5)
+    --     local pp = player:get_pos()
+    --     local fp = vector.add(pp, dis)
+    --     fp.y = fp.y + 2
+    --     minetest.add_entity(fp, "core:console")
+    -- end
+    on_use = function(itemstack, player, pointed_thing)
+        local player_name = player:get_player_name()
+        minetest.show_formspec(player_name, "core:console",
+                               "formspec_version[3]size[10,3,false]" ..
+                                   "field[0.5,0.5;9,1;host;Remote host;tcp!localhost!1917]" ..
+                                   "button_exit[7,1.8;2.5,0.9;connect;connect]")
+    end
+})

--- a/mods/core/tools/console.lua
+++ b/mods/core/tools/console.lua
@@ -1,22 +1,13 @@
-minetest.register_tool("core:console", {
-    desription = "Attach to Console",
+minetest.register_tool("core:spawn_console", {
+    desription = "Spawn Console Cube",
     inventory_image = "core_console.png",
     wield_image = "core_console.png",
-    tool_capabilities = {punch_attack_uses = 0, damage_groups = {console = 1}},
 
-    -- on_use = function(itemstack, player, pointed_thing)
-    --     local dir = player:get_look_dir()
-    --     local dis = vector.multiply(dir, 5)
-    --     local pp = player:get_pos()
-    --     local fp = vector.add(pp, dis)
-    --     fp.y = fp.y + 2
-    --     minetest.add_entity(fp, "core:console")
-    -- end
     on_use = function(itemstack, player, pointed_thing)
         local player_name = player:get_player_name()
-        minetest.show_formspec(player_name, "core:console",
+        minetest.show_formspec(player_name, "core:spawn_console",
                                "formspec_version[3]size[10,3,false]" ..
-                                   "field[0.5,0.5;9,1;host;Remote host;tcp!localhost!1917]" ..
-                                   "button_exit[7,1.8;2.5,0.9;connect;connect]")
+                                   "field[0.5,0.5;9,1;remote_address;Remote host;tcp!localhost!1917]" ..
+                                   "button_exit[7,1.8;2.5,0.9;spawn_attach;connect]")
     end
 })


### PR DESCRIPTION
Added tool for spawning console entity attached to specific host. On entity punch provides formspec with output textarea and input field. String from input field send to cmdchan and output from cmdchan concatenated to the output in textarea. 