### PR TITLE
Fix spawn

### DIFF
--- a/libs/readdir.lua
+++ b/libs/readdir.lua
@@ -29,7 +29,6 @@ function _9p_readdir(ctx, path)
       break
     end
     dir = dir .. tostring(data)
-    pprint(dir)
     offset = offset + #(tostring(data))
   end
   ctx:clunk(f)
@@ -39,7 +38,6 @@ end
 function readdir(ctx, path) 
   local dir = {}
   local dirdata = _9p_readdir(ctx, path)
-  pprint(dirdata)
   while 1 do
     local st = ctx:getstat(data.new(dirdata)) 
     if st == nil then return nil end  

--- a/libs/readdir.lua
+++ b/libs/readdir.lua
@@ -1,12 +1,12 @@
 local data = require 'data'
 local np = require '9p'
-
+local pprint = require 'pprint'
 local ORDONLY = 0
 local OWRITE = 1
 local ORDWR = 2
 local OEXEC = 3 
 
-local READ_BUF_SIZ = 4096
+local READ_BUF_SIZ = 8096
 
 function _9p_readdir(ctx, path) 
   local f = ctx:newfid()
@@ -29,6 +29,7 @@ function _9p_readdir(ctx, path)
       break
     end
     dir = dir .. tostring(data)
+    pprint(dir)
     offset = offset + #(tostring(data))
   end
   ctx:clunk(f)
@@ -38,6 +39,7 @@ end
 function readdir(ctx, path) 
   local dir = {}
   local dirdata = _9p_readdir(ctx, path)
+  pprint(dirdata)
   while 1 do
     local st = ctx:getstat(data.new(dirdata)) 
     if st == nil then return nil end  

--- a/mods/core/automount.lua
+++ b/mods/core/automount.lua
@@ -101,7 +101,9 @@ spawn_root_platform = function(attach_string, player, last_login)
                 root_platform.mount_point = "/"
                 root_platform.origin_point = result
                 root_platform:set_node(player_graph:add_platform(root_platform, nil, player_host_node))
-                root_platform:spawn(vector.round(player:get_pos()), player, math.random(0, 255))
+                local point = vector.round(player:get_pos())
+                root_platform.root_point = point
+                root_platform:spawn(point, player, math.random(0, 255))
                 minetest.show_formspec(player_name, "", "")
             end)
         end

--- a/mods/core/buffer.lua
+++ b/mods/core/buffer.lua
@@ -1,0 +1,75 @@
+class 'buffer'
+
+function buffer:buffer(conn, path)
+    -- tcp 9p socket connection
+    self.conn = conn
+    self.path = path
+    self.fid = nil
+    self.fid_open = false
+    self.offset = 0
+    self.content = {}
+end
+
+function buffer:open()
+    local conn = self.conn
+    local path = self.path
+    local fid = conn:newfid()
+    conn:walk(conn.rootfid, fid, self.path == "/" and "./" or self.path)
+    conn:open(fid, 0)
+    self.fid = fid
+    self.offset = 0
+    self.fid_open = true
+end
+
+function buffer:is_open()
+    return self.fid_open
+end
+
+function buffer:close()
+    self.conn:clunk(self.fid)
+    self.fid_open = false
+end
+
+function buffer:read_next()
+    if not self:is_open() then
+        self:open()
+    end
+    local buf_size = 4096
+    local read_data = self.conn:read(self.fid, self.offset, buf_size)
+    local dir = tostring(read_data)
+    if not read_data then
+        self:close()
+        return nil
+    else
+        self.offset = self.offset + #(tostring(read_data))
+        return dir
+    end
+end
+
+function buffer:parse_raw(raw_content, append)
+    local content_chunk = {}
+    while true do
+        local st = self.conn:getstat(data.new(raw_content))
+        if st == nil then
+            if append then
+                return self.content
+            else
+                return content_chunk
+            end
+        end
+        if append then
+            table.insert(self.content, st)
+        else
+            table.insert(content_chunk, st)
+        end
+        raw_content = raw_content:sub(st.size + 3)
+        if (#raw_content == 0) then
+            break
+        end
+        if append then
+            return self.content
+        else
+            return content_chunk
+        end
+    end
+end

--- a/mods/core/buffer.lua
+++ b/mods/core/buffer.lua
@@ -7,7 +7,7 @@ function buffer:buffer(conn, path)
     self.fid = nil
     self.fid_open = false
     self.offset = 0
-    self.content = {}
+    self.content = nil
 end
 
 function buffer:open()
@@ -18,6 +18,7 @@ function buffer:open()
     conn:open(fid, 0)
     self.fid = fid
     self.offset = 0
+    self.content = {}
     self.fid_open = true
 end
 
@@ -66,10 +67,10 @@ function buffer:parse_raw(raw_content, append)
         if (#raw_content == 0) then
             break
         end
-        if append then
-            return self.content
-        else
-            return content_chunk
-        end
+    end
+    if append then
+        return self.content
+    else
+        return content_chunk
     end
 end

--- a/mods/core/common.lua
+++ b/mods/core/common.lua
@@ -22,8 +22,13 @@ function common.get_platform_string(player)
     if not node_pos then
         return
     end
-    local meta = minetest.get_meta(node_pos)
-    return meta:get_string("platform_string")
+    local area = area_store:get_areas_for_pos(node_pos, false, true)
+        local index, value = next(area)
+        if not value then
+            minetest.chat_send_player(player_name, "No platform for this position in AreaStore")
+            return
+        end
+   return value.data
 end
 
 function common.qid_as_key(dir)

--- a/mods/core/events/core.lua
+++ b/mods/core/events/core.lua
@@ -24,6 +24,7 @@ connect = function(player, fields)
         root_platform.mount_point = "/"
         local point = vector.round(player:get_pos())
         root_platform.origin_point = point
+        root_platform.root_point = point
         root_platform:set_node(player_graph:add_platform(root_platform, nil, host_node))
         root_platform:spawn(point, player, math.random(0, 255))
     end

--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -57,6 +57,7 @@ require 'common'
 require 'np_prot'
 require 'texture'
 require 'mounts'
+require 'buffer'
 
 -- entities
 require 'entities.stat'

--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -79,3 +79,4 @@ crafts = {}
 form_handlers = {}
 
 root_cmdchan = automount()
+area_store = AreaStore()

--- a/mods/core/nodes/platform.lua
+++ b/mods/core/nodes/platform.lua
@@ -9,13 +9,14 @@ minetest.register_node("core:platform", {
     pointable = true,
     diggable = true,
     palette = "core_palette.png",
+    paramtype = "none",
     paramtype2 = "color",
     node_box = {
         type = "regular"
     },
     on_punch = function(pos, _, puncher)
         local player_graph = graphs:get_player_graph(puncher:get_player_name())
-        local platform = player_graph:get_platform(common.get_platform_string(puncher))
+        local platform = player_graph:get_platform()
         platform:show_properties(puncher)
     end
 })

--- a/mods/core/nodes/platform.lua
+++ b/mods/core/nodes/platform.lua
@@ -15,8 +15,15 @@ minetest.register_node("core:platform", {
         type = "regular"
     },
     on_punch = function(pos, _, puncher)
-        local player_graph = graphs:get_player_graph(puncher:get_player_name())
-        local platform = player_graph:get_platform()
+        local player_name = puncher:get_player_name()
+        local player_graph = graphs:get_player_graph(player_name)
+        local area = area_store:get_areas_for_pos(pos, false, true)
+        local index, value = next(area)
+        if not value then
+            minetest.chat_send_player(player_name, "No platform for this position in AreaStore")
+            return
+        end
+        local platform = player_graph:get_platform(value.data)
         platform:show_properties(puncher)
     end
 })

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -14,7 +14,7 @@ function platform:platform(connection, path, cmdchan, parent_node)
         player_name = "",
         -- flag indicating that platform update will be mabe by some other function 
         -- than platform:update()
-        external_handler = false,
+        external_handler = true,
         -- period of time, on which readdir() occurs for current platform and if 
         -- new entries are there, they will be spawn and if some of present entities 
         -- are no more in new readdir() they will removed
@@ -85,7 +85,11 @@ function platform:draw(root_point, size, color)
                 local vi = a:index(x, y, z)
                 data[vi] = core_platform_node
                 param2[vi] = color
-                table.insert(slots, {x = x, y = y, z = z})
+                table.insert(slots, {
+                    x = x,
+                    y = y,
+                    z = z
+                })
             end
         end
     end
@@ -219,7 +223,8 @@ function platform:spawn_stat(stat)
     self:configure_entry(directory_entry)
     slot.y = slot.y + 7 + math.random(5)
     local stat_entity = minetest.add_entity(slot, "core:stat")
-    directory_entry:filter(stat_entity --[[, self:load_getattr(directory_entry, stat_entity)]]  --[[, self:load_getattr(directory_entry, stat_entity)]] )
+    directory_entry:filter(
+        stat_entity --[[, self:load_getattr(directory_entry, stat_entity)]] --[[, self:load_getattr(directory_entry, stat_entity)]]  --[[, self:load_getattr(directory_entry, stat_entity)]] --[[, self:load_getattr(directory_entry, stat_entity)]] )
     return directory_entry
 end
 
@@ -298,13 +303,14 @@ end
 function platform:process_content(content, player_graph)
     local index, stat = next(content)
     if not stat then
+        self:set_external_handler_flag(false)
         return
     end
     local directory_entry = self:spawn_stat(stat)
     self.directory_entries[stat.qid.path_hex] = directory_entry
     player_graph:add_entry(self, directory_entry)
     table.remove(content, index)
-    minetest.after(0.5, platform.process_content, self, content, player_graph)
+    minetest.after(0.2, platform.process_content, self, content, player_graph)
 end
 -- returns next free slot. If no free slots, than doubles platform
 -- and returns free slots from there
@@ -347,10 +353,10 @@ function platform:spawn(root_point, player, color, paths)
         common.goto_platform(player, self:get_root_point())
         minetest.after(1, function()
             self:spawn_content(content)
-            -- if paths then
-            --     minetest.after(0.6, platform.spawn_path_step, self, paths, player)
-            -- end
-            -- self:update()
+            if paths then
+                minetest.after(0.1, platform.spawn_path_step, self, paths, player)
+            end
+            self:update()
         end)
     end)
 end

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -69,6 +69,8 @@ function platform:draw(root_point, size, color)
         y = p1.y,
         z = p1.z + size
     }
+    local vm         = minetest.get_voxel_manip()
+    local emin, emax = vm:read_from_map(p1, p2)
     for z = p1.z, p2.z do
         for y = p1.y, p2.y do
             for x = p1.x, p2.x do
@@ -103,6 +105,8 @@ function platform:colorize(color)
         y = p1.y,
         z = p1.z + self.size
     }
+    local vm         = minetest.get_voxel_manip()
+    local emin, emax = vm:read_from_map(p1, p2)
     for z = p1.z, p2.z do
         for y = p1.y, p2.y do
             for x = p1.x, p2.x do
@@ -144,6 +148,8 @@ function platform:wipe()
         y = p1.y,
         z = p1.z + size
     }
+    local vm         = minetest.get_voxel_manip()
+    local emin, emax = vm:read_from_map(p1, p2)
     for z = p1.z, p2.z do
         for y = p1.y, p2.y do
             for x = p1.x, p2.x do
@@ -169,6 +175,8 @@ function platform:delete_nodes()
         y = p1.y,
         z = p1.z + size
     }
+    local vm         = minetest.get_voxel_manip()
+    local emin, emax = vm:read_from_map(p1, p2)
     for z = p1.z, p2.z do
         for y = p1.y, p2.y do
             for x = p1.x, p2.x do
@@ -396,6 +404,8 @@ function platform:enlarge()
         y = p1.y,
         z = p1.z + size
     }
+    local vm         = minetest.get_voxel_manip()
+    local emin, emax = vm:read_from_map(p1, p2)
     for z = p1.z, p2.z do
         for y = p1.y, p2.y do
             for x = p1.x, p2.x do

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -69,6 +69,7 @@ function platform:draw(root_point, size, color)
         y = p1.y,
         z = p1.z + size
     }
+    area_store:insert_area(p1, p2, self.platform_string)
     local core_platform_node = minetest.get_content_id("core:platform")
     local vm = minetest.get_voxel_manip()
     local emin, emax = vm:read_from_map(p1, p2)

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -292,25 +292,21 @@ end
 -- takes results of readdir and spawn each directory entry from it
 function platform:spawn_content(content)
     local player_graph = graphs:get_player_graph(self:get_player())
-
     self:process_content(content, player_graph, #content)
-    -- for _, stat in pairs(content) do
-    --     local directory_entry = self:spawn_stat(stat)
-    --     self.directory_entries[stat.qid.path_hex] = directory_entry
-    --     player_graph:add_entry(self, directory_entry)
-    -- end
 end
 
 function platform:process_content(content, player_graph, content_size)
     local index, stat = next(content)
     local spawned_entity_count = common.table_length(self.directory_entries)
     if not stat then
-        minetest.chat_send_player(self:get_player(), "Entities spawned at " .. self.platform_string .. ": " .. spawned_entity_count .. "/" .. content_size)
+        minetest.chat_send_player(self:get_player(), "Entities spawned at " .. self.platform_string .. ": " ..
+            spawned_entity_count .. "/" .. content_size)
         self:set_external_handler_flag(false)
         return
     end
     if spawned_entity_count % 100 == 0 and spawned_entity_count ~= 0 then
-        minetest.chat_send_player(self:get_player(), "Entities spawned at " .. self.platform_string .. ": " .. spawned_entity_count .. "/" .. content_size)
+        minetest.chat_send_player(self:get_player(), "Entities spawned at " .. self.platform_string .. ": " ..
+            spawned_entity_count .. "/" .. content_size)
     end
     local directory_entry = self:spawn_stat(stat)
     self.directory_entries[stat.qid.path_hex] = directory_entry
@@ -349,14 +345,14 @@ end
 -- read directory and spawn platform with directory content 
 function platform:spawn(root_point, player, color, paths)
     local content = self:readdir()
-    if not content then
+    if not content or type(content) ~= "table" then
         return nil
     end
     -- self:load_readdir()
     local size = self:compute_size(content)
     minetest.after(1, function()
-        self:draw(root_point, size, color)
         common.goto_platform(player, self:get_root_point())
+        self:draw(root_point, size, color)
         minetest.after(1.5, function()
             self:spawn_content(content)
             if paths then
@@ -403,6 +399,7 @@ function platform:spawn_child(path, player, paths)
     end
     child_platform.mount_point = self.mount_point
     child_platform.origin_point = pos
+    child_platform.root_point = pos
     mounts:set_mount_points(self)
     child_platform:spawn(pos, player, self:get_color(), paths)
     self:inc_spawn_count()

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -73,6 +73,7 @@ function platform:draw(root_point, size, color)
     local vm = minetest.get_voxel_manip()
     local emin, emax = vm:read_from_map(p1, p2)
     local data = vm:get_data()
+    local param2 = vm:get_param2_data()
     local a = VoxelArea:new{
         MinEdge = emin,
         MaxEdge = emax
@@ -82,18 +83,13 @@ function platform:draw(root_point, size, color)
             for x = p1.x, p2.x do
                 local vi = a:index(x, y, z)
                 data[vi] = core_platform_node
-                -- minetest.add_node(p, {
-                --     name = "core:platform",
-                --     param1 = 0,
-                --     param2 = color
-                -- })
-                -- local node = minetest.get_meta(p)
-                -- node:set_string("platform_string", self.platform_string)
+                param2[vi] = color
                 table.insert(slots, {x = x, y = y, z = z})
             end
         end
     end
     vm:set_data(data)
+    vm:set_param2_data(param2)
     vm:write_to_map(true)
     table.shuffle(slots)
     self.slots = slots

--- a/mods/core/platform.lua
+++ b/mods/core/platform.lua
@@ -333,7 +333,8 @@ end
 -- read directory and spawn platform with directory content 
 function platform:spawn(root_point, player, color, paths)
     local root_buffer = buffer(self:get_conn(), self.path)
-    local content = root_buffer:process_next({})
+    local result, content = pcall(root_buffer.process_next, root_buffer, {})
+    if not result then return end 
     local size = self:compute_size(content)
     minetest.after(1, function()
         common.goto_platform(player, self:get_root_point())


### PR DESCRIPTION
With this request one 9p read occurs and after that response is parsed to stats entries and they spawned in batch (depending on the buffer size. With 8kb is approximately 110 entities are spawn at once).

Platform nodes are placed and param2 (color) set with voxelmanip. Platform string for graph now cored in AreaStore instead of setting platform_string as a metadata on each node.  

Resolves #55, Resolves #62 