### PR TITLE
Feature manfs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Minetest Container Image
 on: push
 jobs:
   build:
+    name: Build and Push Docker Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -11,13 +12,13 @@ jobs:
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
 
-      - name: build image
+      - name: Build Docker Image
         run: docker build -t ${{ secrets.REGISTRY_ORGANIZATION }}/minetest:${GITHUB_REF##*/} .
 
-      - name: login to hub.docker.com
+      - name: Login to hub.docker.com
         run: docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: push image to registry
+      - name: Push Image to Registry
         run: docker image push ${{ secrets.REGISTRY_ORGANIZATION }}/minetest:${GITHUB_REF##*/}
 
       # - name: build client image

--- a/mods/core/automount.lua
+++ b/mods/core/automount.lua
@@ -45,13 +45,14 @@ function automount:mount_registry()
     minetest.after(1.5, automount.mount_manuals, self)
 end
 
-function automount:mount_manuals()
-    local root_cmdchan = self.root_cmdchan
+function automount:mount_manuals(cmdchan)
+    local root_cmdchan = cmdchan or self.root_cmdchan
+    root_cmdchan:execute("mkdir -p ".. core_conf:get("mans_path"))
     local man_addr = root_cmdchan:execute("ndb/regquery -n description 'manuals'"):gsub("\n", "")
     if man_addr:match(".*!.*!.*") then
         root_cmdchan:execute("mount -A " .. man_addr .. " " .. core_conf:get("mans_path"))
     else
-        minetest.after(1.5, automount.mount_manuals, self)
+        minetest.after(1.5, automount.mount_manuals, self, cmdchan)
     end
 end
 
@@ -119,7 +120,7 @@ function automount:spawn_root_platform(attach_string, player, last_login, random
             })
         end
         local result = player:get_pos()
-        minetest.after(1.5, automount.mount_manuals, self)
+        minetest.after(1.5, automount.mount_manuals, self, user_cmdchan)
         minetest.after(2, function(result)
             local root_platform = platform(connection, "/", user_cmdchan, player_host_node)
             root_platform:set_player(player_name)

--- a/mods/core/automount.lua
+++ b/mods/core/automount.lua
@@ -49,7 +49,6 @@ function automount:mount_manuals()
     local root_cmdchan = self.root_cmdchan
     local man_addr = root_cmdchan:execute("ndb/regquery -n description 'manuals'"):gsub("\n", "")
     if man_addr:match(".*!.*!.*") then
-        print("man addr is " .. man_addr)
         root_cmdchan:execute("mount -A " .. man_addr .. " " .. core_conf:get("mans_path"))
     else
         minetest.after(1.5, automount.mount_manuals, self)

--- a/mods/core/automount.lua
+++ b/mods/core/automount.lua
@@ -42,6 +42,18 @@ function automount:mount_registry()
         print("Registry mount failed. Retry")
         minetest.after(1, automount.mount_registry, self)
     end
+    minetest.after(1.5, automount.mount_manuals, self)
+end
+
+function automount:mount_manuals()
+    local root_cmdchan = self.root_cmdchan
+    local man_addr = root_cmdchan:execute("ndb/regquery -n description 'manuals'"):gsub("\n", "")
+    if man_addr:match(".*!.*!.*") then
+        print("man addr is " .. man_addr)
+        root_cmdchan:execute("mount -A " .. man_addr .. " " .. core_conf:get("mans_path"))
+    else
+        minetest.after(1.5, automount.mount_manuals, self)
+    end
 end
 
 function automount:poll_user_management()
@@ -71,7 +83,8 @@ function automount:poll_regquery(player, counter, last_login)
         minetest.chat_send_player(player_name, user_addr .. " mounted")
         minetest.show_formspec(player_name, "core:some_form",
             table.concat({"formspec_version[4]", "size[20, 1.2,false]",
-                          "hypertext[0, 0.3; 20, 1;; <bigger><center>User addr ", user_addr, " found.<center><bigger>]"}, ""))
+                          "hypertext[0, 0.3; 20, 1;; <bigger><center>User addr ", user_addr, " found.<center><bigger>]"},
+                ""))
         self:spawn_root_platform(user_addr, player, last_login, true)
     else
         minetest.after(2, automount.poll_regquery, self, player, counter, last_login)

--- a/mods/core/automount.lua
+++ b/mods/core/automount.lua
@@ -120,6 +120,7 @@ function automount:spawn_root_platform(attach_string, player, last_login, random
             })
         end
         local result = player:get_pos()
+        minetest.after(1.5, automount.mount_manuals, self)
         minetest.after(2, function(result)
             local root_platform = platform(connection, "/", user_cmdchan, player_host_node)
             root_platform:set_player(player_name)

--- a/mods/core/chat/cmdchan.lua
+++ b/mods/core/chat/cmdchan.lua
@@ -6,13 +6,23 @@ minetest.register_on_chat_message(function(player_name, message)
         minetest.chat_send_player(player_name, "No platform found nearby")
         return true
     end
+    local commands = core_conf:get("pcmd")
+    local command = message:match("[^ ]+")
+    if command:match("man") and message:match(" | man$") then
+        message = message:gsub(" | man", "")
+        local conn = platform:get_conn()
+        local section = message:match("man %d+ ") and command:gsub("man ", ""):match("%d+") or "1"
+        message = message:gsub("man ", ""):gsub("%d+ ", "")
+        local mans_path = core_conf:get("mans_path")
+        local manpage = np_prot.file_read(conn, mans_path .. "/" .. section .. "/" .. message)
+        common.show_man(player_name, manpage)
+        return true
+    end
     local cmdchan = platform:get_cmdchan()
     if not cmdchan then
         return
     end
     local path = platform:get_path()
-    local commands = core_conf:get("pcmd")
-    local command = message:match("[^ ]+")
     if commands:match(command) then
         if message:match("| minetest$") then
             message = message:gsub("| minetest", "")
@@ -24,9 +34,9 @@ minetest.register_on_chat_message(function(player_name, message)
             common.add_ns_to_inventory(player, result)
         elseif message:match(" | man$") then
             message = message:gsub("| man", "")
-            local response = cmdchan:execute(message)            
+            local response = cmdchan:execute(message)
             local player_name = player:get_player_name()
-            common.show_man(player_name, common.parse_man(response))
+            common.show_man(player_name, response)
         else
             local result = cmdchan:execute(message, path)
             minetest.chat_send_player(player_name, result .. "\n")
@@ -52,15 +62,17 @@ local man_event = function(player, formname, fields)
             minetest.chat_send_player(player_name, "No platform found nearby")
             return true
         end
-        local cmdchan = platform:get_cmdchan()
-        if not cmdchan then
-            return
-        end
         local k, v = next(fields)
+        print(v)
         v = v:gsub("action:", "")
+        local c = v:match("%(%d+%)")
+        local section = c:match("%d+")
+        local man = v:gsub("%(%d+%)", "")
         local path = platform:get_path()
-        local response = cmdchan:execute("man " .. v)    
-        common.show_man(player_name, common.parse_man(response))
+        local conn = platform:get_conn()
+        local mans_path = core_conf:get("mans_path")
+        local manpage = np_prot.file_read(conn, mans_path .. "/" .. section .. "/" .. man)
+        common.show_man(player_name, manpage)
     end
 end
 

--- a/mods/core/chat/cmdchan.lua
+++ b/mods/core/chat/cmdchan.lua
@@ -22,8 +22,10 @@ minetest.register_on_chat_message(function(player_name, message)
                     break
                 end
             end
+            if not result then 
             minetest.chat_send_player(player_name, "Error reading accross all sections: " .. manpage)
             return true
+            end
         else
             result, manpage = pcall(np_prot.file_read, conn, mans_path .. "/" .. section .. "/" .. message)
         end

--- a/mods/core/chat/cmdchan.lua
+++ b/mods/core/chat/cmdchan.lua
@@ -14,8 +14,12 @@ minetest.register_on_chat_message(function(player_name, message)
         local section = message:match("man %d+ ") and command:gsub("man ", ""):match("%d+") or "1"
         message = message:gsub("man ", ""):gsub("%d+ ", "")
         local mans_path = core_conf:get("mans_path")
-        local manpage = np_prot.file_read(conn, mans_path .. "/" .. section .. "/" .. message)
-        common.show_man(player_name, manpage)
+        local result, manpage = pcall(np_prot.file_read, conn, mans_path .. "/" .. section .. "/" .. message)
+        if not result then
+            minetest.chat_send_player(player_name, "Error reading manpage: " .. manpage)
+        else
+            common.show_man(player_name, manpage)
+        end
         return true
     end
     local cmdchan = platform:get_cmdchan()
@@ -32,11 +36,6 @@ minetest.register_on_chat_message(function(player_name, message)
             message = message:gsub("| inventory", "")
             local result = cmdchan:execute(message)
             common.add_ns_to_inventory(player, result)
-        elseif message:match(" | man$") then
-            message = message:gsub("| man", "")
-            local response = cmdchan:execute(message)
-            local player_name = player:get_player_name()
-            common.show_man(player_name, response)
         else
             local result = cmdchan:execute(message, path)
             minetest.chat_send_player(player_name, result .. "\n")
@@ -63,16 +62,18 @@ local man_event = function(player, formname, fields)
             return true
         end
         local k, v = next(fields)
-        print(v)
         v = v:gsub("action:", "")
         local c = v:match("%(%d+%)")
         local section = c:match("%d+")
         local man = v:gsub("%(%d+%)", "")
-        local path = platform:get_path()
         local conn = platform:get_conn()
         local mans_path = core_conf:get("mans_path")
-        local manpage = np_prot.file_read(conn, mans_path .. "/" .. section .. "/" .. man)
-        common.show_man(player_name, manpage)
+        local result, manpage = pcall(np_prot.file_read, conn, mans_path .. "/" .. section .. "/" .. man)
+        if not result then
+            minetest.chat_send_player(player_name, "Error reading manpage: " .. manpage)
+        else
+            common.show_man(player_name, manpage)
+        end
     end
 end
 

--- a/mods/core/chat/cmdchan.lua
+++ b/mods/core/chat/cmdchan.lua
@@ -28,8 +28,8 @@ minetest.register_on_chat_message(function(player_name, message)
             result, manpage = pcall(np_prot.file_read, conn, mans_path .. "/" .. section .. "/" .. message)
         end
         if not result then
-            minetest.chat_send_player(player_name, "Error reading accross all sections: " .. manpage)
-            return
+            minetest.chat_send_player(player_name, "Error reading manual: " .. manpage)
+            return true
         end
         common.show_man(player_name, manpage)
         return true

--- a/mods/core/common.lua
+++ b/mods/core/common.lua
@@ -424,7 +424,7 @@ local links = {}
     end
     
     for k, v in pairs(links) do 
-        manpage = manpage:gsub(k:gsub("%(", "%%%("):gsub("%)", "%%%)"):gsub("%-", "%%%-"), "<action name=" .. k:match("[%a%-%d]+").. ">".. k .."</action>")
+        manpage = manpage:gsub(k:gsub("%(", "%%%("):gsub("%)", "%%%)"):gsub("%-", "%%%-"), "<action name=" .. k .. ">".. k .."</action>")
     end
     return manpage
 end

--- a/mods/core/mod.conf
+++ b/mods/core/mod.conf
@@ -11,7 +11,7 @@ pcmd=pwd,ls,cat,rm,touch,mkdir,echo,ps,tail,mount,bind,unmount,getip,ns,rc,man
 
 refresh_time=3
 registry_path=/mnt/registry
-mans_path=/man
+mans_path=/manfs
 
 INFERNO_ADDR=tcp!localhost!1917
 REGISTRY_ADDR=tcp!registry.dev.metacoma.io!30099

--- a/mods/core/mod.conf
+++ b/mods/core/mod.conf
@@ -16,3 +16,4 @@ mans_path=/man
 INFERNO_ADDR=tcp!localhost!1917
 REGISTRY_ADDR=tcp!registry.dev.metacoma.io!30099
 GRIDFILES_ADDR=tcp!gridfiles.dev.metacoma.io!30098
+MANUALS_ADDR=tcp!manuals.dev.metacoma.io!30088

--- a/mods/core/mod.conf
+++ b/mods/core/mod.conf
@@ -11,6 +11,7 @@ pcmd=pwd,ls,cat,rm,touch,mkdir,echo,ps,tail,mount,bind,unmount,getip,ns,rc,man
 
 refresh_time=3
 registry_path=/mnt/registry
+mans_path=/man
 
 INFERNO_ADDR=tcp!localhost!1917
 REGISTRY_ADDR=tcp!registry.dev.metacoma.io!30099


### PR DESCRIPTION
Automount manfs on server startup and onto home platfrom

Supported syntax 
`man <manual> | man` - searches for <manual> across all sections
`man <section> <manual> | man` -- looks just in specific section for man page.

Issue #78 